### PR TITLE
[2.x] Move `registerMacros` call to the `boot` method

### DIFF
--- a/src/LocalizedRoutesServiceProvider.php
+++ b/src/LocalizedRoutesServiceProvider.php
@@ -33,7 +33,6 @@ final class LocalizedRoutesServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerPublishableFiles();
-        $this->registerMacros();
     }
 
     /**
@@ -47,6 +46,7 @@ final class LocalizedRoutesServiceProvider extends ServiceProvider
         $this->registerUrlGenerator();
         $this->registerRedirector();
         $this->registerProviders();
+        $this->registerMacros();
     }
 
     /**


### PR DESCRIPTION
This change allows using the macro's in the `boot` method of a service provider.