### PR TITLE
[1.x] Move `registerMacros` call to the `boot` method

### DIFF
--- a/src/LocalizedRoutesServiceProvider.php
+++ b/src/LocalizedRoutesServiceProvider.php
@@ -32,7 +32,6 @@ class LocalizedRoutesServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerPublishableFiles();
-        $this->registerMacros();
     }
 
     /**
@@ -48,6 +47,7 @@ class LocalizedRoutesServiceProvider extends ServiceProvider
         $this->registerUrlGenerator();
         $this->registerRedirector();
         $this->registerProviders();
+        $this->registerMacros();
     }
 
     /**


### PR DESCRIPTION
This change allows using the macro's in the `boot` method of a service provider.